### PR TITLE
feat: Add auth views and shared preferences

### DIFF
--- a/lib/animated_splash_view.dart
+++ b/lib/animated_splash_view.dart
@@ -4,6 +4,8 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:fruit_hub/features/onboarding/presentation/views/onboarding_view.dart';
 import 'package:fruit_hub/generated/assets.dart';
+import 'core/helpers/shared_preferences_manager.dart';
+import 'features/auth/presentation/views/login_view.dart';
 
 class AnimatedSplashView extends StatefulWidget {
   const AnimatedSplashView({super.key});
@@ -20,10 +22,11 @@ class _AnimatedSplashViewState extends State<AnimatedSplashView> {
   }
 
   void navigate() async {
+    bool firstTime = await getFirstTime();
     Future.delayed(const Duration(seconds: 2, milliseconds: 300), () {
       Navigator.of(context).pushReplacement(
         PageRouteBuilder(
-          pageBuilder: (_, __, ___) => const OnboardingView(),
+          pageBuilder: (_, __, ___) => _getView(firstTime),
           transitionsBuilder: (_, animation, __, child) {
             return FadeTransition(
               opacity: CurvedAnimation(
@@ -36,6 +39,16 @@ class _AnimatedSplashViewState extends State<AnimatedSplashView> {
         ),
       );
     });
+  }
+
+  Future<bool> getFirstTime() async =>
+      await SharedPreferencesManager.getFirstTime();
+
+  Widget _getView(bool firstTime) {
+    if (firstTime) {
+      return const OnboardingView();
+    }
+    return const LoginView();
   }
 
   @override

--- a/lib/core/helpers/shared_preferences_manager.dart
+++ b/lib/core/helpers/shared_preferences_manager.dart
@@ -1,0 +1,16 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SharedPreferencesManager {
+  static late SharedPreferences _prefs;
+
+  static const String isFirstTimeKey = 'isFirstTime';
+
+  static Future<void> init() async =>
+      _prefs = await SharedPreferences.getInstance();
+
+  static Future<void> setFirstTime(bool isFirstTime) async =>
+      await _prefs.setBool(isFirstTimeKey, isFirstTime);
+
+  static Future<bool> getFirstTime() async =>
+      _prefs.getBool(isFirstTimeKey) ?? true;
+}

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -2,6 +2,8 @@ import 'package:flutter/cupertino.dart';
 import 'package:fruit_hub/core/routing/routes.dart';
 import 'package:fruit_hub/animated_splash_view.dart';
 import 'package:fruit_hub/features/onboarding/presentation/views/onboarding_view.dart';
+import '../../features/auth/presentation/views/login_view.dart';
+import '../../features/auth/presentation/views/register_view.dart';
 
 class AppRouter {
   Route? generateRoute(RouteSettings settings) {
@@ -15,6 +17,10 @@ class AppRouter {
         );
       case Routes.onboardingView:
         return CupertinoPageRoute(builder: (context) => const OnboardingView());
+      case Routes.loginView:
+        return CupertinoPageRoute(builder: (context) => const LoginView());
+      case Routes.registerView:
+        return CupertinoPageRoute(builder: (context) => const RegisterView());
       default:
         return null;
     }

--- a/lib/core/routing/routes.dart
+++ b/lib/core/routing/routes.dart
@@ -1,4 +1,6 @@
 class Routes {
   static const splashView = '/splashView';
   static const onboardingView = '/onboardingView';
+  static const loginView = '/loginView';
+  static const registerView = '/registerView';
 }

--- a/lib/features/auth/presentation/views/login_view.dart
+++ b/lib/features/auth/presentation/views/login_view.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class LoginView extends StatelessWidget {
+  const LoginView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold();
+  }
+}

--- a/lib/features/auth/presentation/views/register_view.dart
+++ b/lib/features/auth/presentation/views/register_view.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class RegisterView extends StatelessWidget {
+  const RegisterView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold();
+  }
+}

--- a/lib/features/onboarding/presentation/views/onboarding_view.dart
+++ b/lib/features/onboarding/presentation/views/onboarding_view.dart
@@ -2,10 +2,13 @@ import 'package:animate_do/animate_do.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:fruit_hub/core/helpers/extentions.dart';
+import 'package:fruit_hub/core/routing/routes.dart';
 import 'package:fruit_hub/core/theming/app_text_styles.dart';
 import 'package:fruit_hub/core/widgets/custom_material_button.dart';
 import 'package:fruit_hub/features/onboarding/data/models/onboarding_model.dart';
 import 'package:gap/gap.dart';
+import '../../../../core/helpers/shared_preferences_manager.dart';
 import '../widgets/onboarding_indicator.dart';
 import '../widgets/onboarding_page_view.dart';
 
@@ -47,7 +50,10 @@ class _OnboardingViewState extends State<OnboardingView> {
                 duration: const Duration(milliseconds: 500),
                 from: 50,
                 child: CustomMaterialButton(
-                  onPressed: () {},
+                  onPressed: () {
+                    SharedPreferencesManager.setFirstTime(false);
+                    context.pushReplacementNamed(Routes.loginView);
+                  },
                   maxWidth: true,
                   text: "start_now".tr(),
                   textStyle: AppTextStyles.font16WhiteBold,

--- a/lib/features/onboarding/presentation/widgets/page_view_item.dart
+++ b/lib/features/onboarding/presentation/widgets/page_view_item.dart
@@ -2,7 +2,10 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:fruit_hub/core/helpers/extentions.dart';
+import 'package:fruit_hub/core/helpers/shared_preferences_manager.dart';
 import 'package:gap/gap.dart';
+import '../../../../core/routing/routes.dart';
 import '../../../../core/theming/app_text_styles.dart';
 import '../../data/models/onboarding_model.dart';
 
@@ -26,9 +29,15 @@ class PageViewItem extends StatelessWidget {
                 top: 60.h,
                 right: context.locale.languageCode == 'ar' ? 20.w : null,
                 left: context.locale.languageCode == 'en' ? 20.w : null,
-                child: Text(
-                  "skip".tr(),
-                  style: AppTextStyles.font13color949D9ERegular,
+                child: GestureDetector(
+                  onTap: () {
+                    SharedPreferencesManager.setFirstTime(false);
+                    context.pushReplacementNamed(Routes.loginView);
+                  },
+                  child: Text(
+                    "skip".tr(),
+                    style: AppTextStyles.font13color949D9ERegular,
+                  ),
                 ),
               ),
           ],
@@ -59,7 +68,10 @@ class PageViewItem extends StatelessWidget {
                 text: slide.title.substring(0, slide.title.length - 8),
                 style: AppTextStyles.font22color0C0D0DBold,
               ),
-              TextSpan(text: 'Fruit', style: AppTextStyles.font22color1B5E37Bold),
+              TextSpan(
+                text: 'Fruit',
+                style: AppTextStyles.font22color1B5E37Bold,
+              ),
               TextSpan(text: 'HUB', style: AppTextStyles.font22colorF4A91FBold),
             ],
           ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,10 +2,16 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:fruit_hub/core/routing/app_router.dart';
 import 'package:fruit_hub/fruit_hub.dart';
+import 'core/helpers/shared_preferences_manager.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await EasyLocalization.ensureInitialized();
+
+  await Future.wait([
+    SharedPreferencesManager.init(),
+    EasyLocalization.ensureInitialized(),
+  ]);
+
   runApp(
     EasyLocalization(
       supportedLocales: [const Locale('ar'), const Locale('en')],


### PR DESCRIPTION
- Added `LoginView` and `RegisterView` for user authentication.
- Implemented `SharedPreferencesManager` to handle persistent storage, specifically for tracking if it's the user's first time opening the app.
- Updated `OnboardingView` to navigate to `LoginView` after completion and set the first-time flag.
- Modified `PageViewItem` in onboarding to allow skipping to `LoginView` and update the first-time flag.
- Updated `AppRouter` to include routes for `LoginView` and `RegisterView`.
- Added new route constants in `Routes`.
- Modified `AnimatedSplashView` to check the first-time flag and navigate to either `OnboardingView` or `LoginView` accordingly.
- Initialized `SharedPreferencesManager` in `main.dart`.